### PR TITLE
Change API to support multiple sessions

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -49,15 +49,19 @@ def new_response(result = apiresults["UNDEFINED"], error_info = None, diff = [],
         response["data"]["diff"] = diff
 
     if session_ID:
-        response["id"] = session_ID
+        response["head"]["id"] = session_ID
 
     #where head["result"] is the result of an operation (if relevant) and data is any data (if relevant)
     return response 
 
 #Request reference, also useful for testing
-def new_request(function = "", data = {}, changes = [], filename = None):
+def new_request(function = "", data = {}, changes = [], filename = None, session_ID = None):
     request = {"head": {"function": function}, "data": data}
 
+    #implementations shouldn't make this optional
+    if session_ID:
+        request["head"]["id"] = session_ID
+    
     match function:
         case "init":
             data["filename"] = filename
@@ -99,7 +103,7 @@ def api():
     head = request.json["head"]
     data = request.json["data"]
     session_ID = None
-    if "id" in data:
+    if "id" in data and data["function"] != "init":
         session_ID = data["id"]
     
     match head["function"]:

--- a/src/app.py
+++ b/src/app.py
@@ -89,6 +89,7 @@ def new_request(function = "", data = {}, changes = [], filename = None, session
 
     return request
 
+#TODO: Once tests are changed to reflect the change to multiple sessions, get rid of _session and clean up any code that handles switching _session and _sessions
 @app.route("/api", methods=["POST"])
 def api():
     global _session

--- a/src/readme.md
+++ b/src/readme.md
@@ -20,8 +20,9 @@ Requests should be JSON objects that look like:
 { 
     "head": 
         {
-            "function": /*mandatory*/ "name of function"
+            "function": /*mandatory*/ "name of function",
                 /*possible values: init, save, close_session, update_chart, get_steps, get_bpms, get_measures, introspect_has_session*/
+            "id": /*mandatory, except when calling 'init'*/ "session ID",
         },
     "data":
         {
@@ -36,7 +37,8 @@ Responses look like:
 { 
     "head": 
         {
-            "result": /*always*/ "status of the operation"
+            "result": /*always*/ "status of the operation",
+            "id": /*always*/ "id of the session affected"
         },
     "data":
         {

--- a/src/runtime.py
+++ b/src/runtime.py
@@ -1,4 +1,5 @@
 from chart_tools_new import *
+import uuid
 
 class LogLevel(Enum):
     BASIC = 0
@@ -16,6 +17,8 @@ class Session:
     def __init__(self, path):
         self.path = path
         self.chart_instance = None
+        self.ID = uuid.uuid4().hex #str
+
         try:
             self.chart_instance = load_from_file(path)
         except FileNotFoundError:

--- a/src/test.py
+++ b/src/test.py
@@ -561,6 +561,28 @@ class TestAPINew(unittest.TestCase):
             result = client.post("/api", json = new_request(function = "get_steps"))
             self.assertEqual(len(result.json["data"]["steps"]), 1)
 
+class TestAPISessions(unittest.TestCase):
+    def test_session_ID(self):
+        app.testing = True
+
+        with app.test_client() as client:
+            result = client.post("/api", json={"head": {"function": "init"}, "data": {"filename": "newchart.xml"}})
+            self.assertEqual(type(result.json["head"]["id"]), type("")) 
+            self.assertNotEqual(result.json["head"]["id"], "") 
+
+            session_ID = result.json["head"]["id"]
+
+            stepdict = new_step_dict(start_tick = 10, end_tick = 20, left_pos = 30, right_pos = 40, kind = 1, player_id =1)
+            result = client.post("/api", json = new_request(function = "update_chart", changes = [stepdict], session_ID = session_ID))
+            self.assertEqual(result.json["head"]["result"], "SUCCESS")
+            self.assertEqual(result.json["data"]["diff"][0], stepdict)
+
+            result = client.post("/api", json = new_request(function = "get_steps", session_ID = session_ID))
+            self.assertEqual(result.json["head"]["result"], "SUCCESS")
+            self.assertEqual(len(result.json["data"]["steps"]), 1)
+
+            #TODO: Actually redo the rest of the tests to work like this and delete these 
+
 if __name__ == "__main__":
     #Charts for dynamic analysis testing (ie not for unit tests)
     generateCompleteChart()


### PR DESCRIPTION
While the api server initially only supported one session, it became apparent that it might be desirable for implementations to be able to have more than one chart open at once. For the time being, it supports both the new multiple sessions usage pattern and the old "one session" pattern in the interest of not breaking tests